### PR TITLE
Fix lexical analyzer bugs

### DIFF
--- a/Compiler/Lexical_analyzer.py
+++ b/Compiler/Lexical_analyzer.py
@@ -58,8 +58,8 @@ def analyze(text):
         ('([a-zA-Z_][a-zA-Z0-9_]*)',    Token.ID),
         ('(\d+)',     Token.NUM),
         ('(0x[A-Fa-f\d]+)',     Token.NUM),  # hexadecimal number
-        ('\"([^\"])*\"',   Token.STRING),
-        ('\'(\\\\)?[^\']\'', Token.CHAR),
+        (r'\"(\\\"|[^"])*"',   Token.STRING),
+        (r'\'(\\\'|(\\)?[^\'])\'', Token.CHAR),
         ('//.*(\\n|$)', Token.COMMENT),
         (r'/\*[\s\S]*?\*/', Token.COMMENT),  # multiline comments
         ('.',       Token.UNIDENTIFIED)


### PR DESCRIPTION
Fixed 2 bugs where the program would fail when the code contained `'\''` or `"\""`