### PR TITLE
Fixed bug related to div zero check

### DIFF
--- a/Compiler/Node.py
+++ b/Compiler/Node.py
@@ -55,7 +55,11 @@ class NodeToken(Node):
             code += self.right.get_code(current_pointer + 1)
             code += "<<"  # point to the first operand
 
-            code += get_op_between_literals_code(self.token, right_token=self.right.token)
+            right_token = None
+            if isinstance(self.right, NodeToken):
+                right_token = self.right.token
+
+            code += get_op_between_literals_code(self.token, right_token)
             return code
 
         elif self.token.type == Token.ASSIGN:


### PR DESCRIPTION
Having the right side of a operation as something other than `NodeToken` caused a crash

```c
char arr[5];
printchar(3+arr[2]);
```