### PR TITLE
Added a warning if for loop variable isn't assigned to anything

### DIFF
--- a/Compiler/FunctionCompiler.py
+++ b/Compiler/FunctionCompiler.py
@@ -871,6 +871,9 @@ class FunctionCompiler:
             manually_inserted_variable_in_for_definition = True
             code += ">" * get_variable_size(variable)
 
+            if self.parser.next_token(2).type != Token.ASSIGN:
+                print("[Warning] For loop variable '%s' isn't assigned to anything and may cause side effects" % self.parser.next_token())
+
         if self.parser.current_token().type == Token.LBRACE:  # statement is a scope
             raise BFSyntaxError("Unexpected scope inside for loop statement - %s" % self.parser.current_token())
         initial_statement = self.compile_statement()


### PR DESCRIPTION
This happened to me where i didn't figure out why it wasn't working after adding a print call.

```bf
int main() {
    print("\033[m"); // Removing this line makes the program work
    //       V Here is the issue
    for(int i; i != 26; i++) {
        for(int j = 0; j != 10; j++) {
            print("\033[48;5;");
            printint(10*i + j);
            print("m \033[m");
        }
        printchar('\n');
    }
}
```